### PR TITLE
Feature/member

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,9 @@ dependencies {
 
 
 	// jwt
-	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
 	// 문자인증
 	implementation 'net.nurigo:sdk:4.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/withus/withmebe/common/entity/BaseEntity.java
+++ b/src/main/java/com/withus/withmebe/common/entity/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.withus.withmebe.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass // 해당 클래스의 필드와 매핑 정보는 하위 엔티티 클래스에 상속
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @Column(nullable = false, updatable = false)
+  @CreatedDate
+  private LocalDateTime createdDttm;
+
+  @LastModifiedDate
+  private LocalDateTime updatedDttm;
+
+  private LocalDateTime deletedDttm;
+}

--- a/src/main/java/com/withus/withmebe/common/exception/ExceptionCode.java
+++ b/src/main/java/com/withus/withmebe/common/exception/ExceptionCode.java
@@ -26,6 +26,7 @@ public enum ExceptionCode {
   ENTITY_NOT_FOUND(NOT_FOUND, "개체를 찾지 못했습니다."),
 
   // Conflict: 409
+  EMAIL_CONFLICT(CONFLICT, "이메일이 중복됩니다.")
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/withus/withmebe/common/exception/ExceptionCode.java
+++ b/src/main/java/com/withus/withmebe/common/exception/ExceptionCode.java
@@ -15,13 +15,14 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ExceptionCode {
   // BAD_REQUEST: 400
-  EX(BAD_REQUEST, "예시입니당"),
+  PASSWORD_CHK_MISMATCH(BAD_REQUEST, "비밀번호 확인이 비밀번호와 일치하지 않습니다."),
 
   // Unauthorized: 401
-
-  // FORBIDDEN: 403
   TOKEN_EXPIRED(UNAUTHORIZED, "토큰이 만료되었습니다."),
   AUTHENTICATION_ISSUE(UNAUTHORIZED, "인증 이슈가 있습니다."),
+
+  // FORBIDDEN: 403
+
   // NOT_FOUND: 404
   ENTITY_NOT_FOUND(NOT_FOUND, "개체를 찾지 못했습니다."),
   PASSWORD_MISMATCH(UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/com/withus/withmebe/common/exception/ExceptionCode.java
+++ b/src/main/java/com/withus/withmebe/common/exception/ExceptionCode.java
@@ -24,6 +24,7 @@ public enum ExceptionCode {
   AUTHENTICATION_ISSUE(UNAUTHORIZED, "인증 이슈가 있습니다."),
   // NOT_FOUND: 404
   ENTITY_NOT_FOUND(NOT_FOUND, "개체를 찾지 못했습니다."),
+  PASSWORD_MISMATCH(UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
   // Conflict: 409
   EMAIL_CONFLICT(CONFLICT, "이메일이 중복됩니다.")

--- a/src/main/java/com/withus/withmebe/common/exception/ExceptionCode.java
+++ b/src/main/java/com/withus/withmebe/common/exception/ExceptionCode.java
@@ -20,9 +20,10 @@ public enum ExceptionCode {
   // Unauthorized: 401
 
   // FORBIDDEN: 403
-
+  TOKEN_EXPIRED(UNAUTHORIZED, "토큰이 만료되었습니다."),
+  AUTHENTICATION_ISSUE(UNAUTHORIZED, "인증 이슈가 있습니다."),
   // NOT_FOUND: 404
-  ENTITY_NOT_FOUND(NOT_FOUND, "개체를 찾지 못했습니다.")
+  ENTITY_NOT_FOUND(NOT_FOUND, "개체를 찾지 못했습니다."),
 
   // Conflict: 409
   ;

--- a/src/main/java/com/withus/withmebe/member/controller/AuthController.java
+++ b/src/main/java/com/withus/withmebe/member/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.withus.withmebe.member.controller;
 
+import com.withus.withmebe.member.dto.SigninDto;
 import com.withus.withmebe.member.dto.SignupDto;
 import com.withus.withmebe.member.service.AuthService;
 import jakarta.validation.Valid;
@@ -20,5 +21,9 @@ public class AuthController {
   @PostMapping("/signup")
   public ResponseEntity<SignupDto.Response> signup(@Valid @RequestBody SignupDto.Request request) {
     return ResponseEntity.ok(authService.signup(request));
+  }
+  @PostMapping("/signin")
+  public ResponseEntity<SigninDto.Response> signin(@Valid @RequestBody SigninDto.Request request) {
+    return ResponseEntity.ok(authService.signin(request));
   }
 }

--- a/src/main/java/com/withus/withmebe/member/controller/AuthController.java
+++ b/src/main/java/com/withus/withmebe/member/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.withus.withmebe.member.controller;
+
+import com.withus.withmebe.member.dto.SignupDto;
+import com.withus.withmebe.member.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  private final AuthService authService;
+
+  @PostMapping("/signup")
+  public ResponseEntity<SignupDto.Response> signup(@Valid @RequestBody SignupDto.Request request) {
+    return ResponseEntity.ok(authService.signup(request));
+  }
+}

--- a/src/main/java/com/withus/withmebe/member/dto/SigninDto.java
+++ b/src/main/java/com/withus/withmebe/member/dto/SigninDto.java
@@ -13,7 +13,7 @@ public record SigninDto() {
   }
 
   public record Response(
-      String token
+      String accessToken
   ) {
 
   }

--- a/src/main/java/com/withus/withmebe/member/dto/SigninDto.java
+++ b/src/main/java/com/withus/withmebe/member/dto/SigninDto.java
@@ -1,0 +1,20 @@
+package com.withus.withmebe.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SigninDto() {
+  public record Request(
+      @NotBlank
+      String email,
+      @NotBlank
+      String password
+  ) {
+
+  }
+
+  public record Response(
+      String token
+  ) {
+
+  }
+}

--- a/src/main/java/com/withus/withmebe/member/dto/SignupDto.java
+++ b/src/main/java/com/withus/withmebe/member/dto/SignupDto.java
@@ -6,8 +6,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 public record SignupDto() {
   public record Request(
@@ -27,12 +27,14 @@ public record SignupDto() {
       Gender gender
   ) {
 
-    public Member toEntity(PasswordEncoder passwordEncoder) {
+    public Member toEntity(String encodedPassword, String nickName) {
       return Member.builder()
           .email(this.email)
-          .password(passwordEncoder.encode(this.password))
+          .password(encodedPassword)
+          .nickName(nickName)
           .birthDate(this.birthDate)
           .gender(this.gender)
+          .signupDttm(LocalDateTime.now())
           .build();
     }
   }

--- a/src/main/java/com/withus/withmebe/member/dto/SignupDto.java
+++ b/src/main/java/com/withus/withmebe/member/dto/SignupDto.java
@@ -1,0 +1,57 @@
+package com.withus.withmebe.member.dto;
+
+import com.withus.withmebe.member.entity.Member;
+import com.withus.withmebe.member.type.Gender;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public record SignupDto() {
+  public record Request(
+      @NotBlank
+      @Email
+      String email,
+      @NotBlank
+      String password,
+      @NotBlank
+      String passwordChk,
+
+      @NotNull
+      @DateTimeFormat(pattern = "yyyy-MM-dd")
+      LocalDate birthDate,
+
+      @NotNull
+      Gender gender
+  ) {
+
+    public Member toEntity(PasswordEncoder passwordEncoder) {
+      return Member.builder()
+          .email(this.email)
+          .password(passwordEncoder.encode(this.password))
+          .birthDate(this.birthDate)
+          .gender(this.gender)
+          .build();
+    }
+  }
+
+  public record Response(
+      Long id,
+      String email,
+      String password,
+      LocalDate birthDate,
+      Gender gender
+  ) {
+
+    public static Response fromEntity(Member member) {
+      return new Response(
+          member.getId(),
+          member.getEmail(),
+          member.getPassword(),
+          member.getBirthDate(),
+          member.getGender());
+    }
+  }
+}

--- a/src/main/java/com/withus/withmebe/member/entity/Member.java
+++ b/src/main/java/com/withus/withmebe/member/entity/Member.java
@@ -24,15 +24,15 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor(force = true)
+@NoArgsConstructor
 public class Member extends BaseEntity {
   @Id
   @GeneratedValue(strategy = IDENTITY)
   @Column(name = "member_id")
-  private final Long id;
+  private Long id;
 
   @Column(unique = true, nullable = false)
-  private final String email;
+  private String email;
 
   private String password;
 
@@ -64,8 +64,7 @@ public class Member extends BaseEntity {
   private Membership membership = FREE;
 
   @Builder
-  public Member(Long memberId, String email, String password, String nickName, LocalDate birthDate, Gender gender, LocalDateTime signupDttm){
-    this.id = memberId;
+  public Member(String email, String password, String nickName, LocalDate birthDate, Gender gender, LocalDateTime signupDttm){
     this.email = email;
     this.password = password;
     this.nickName = nickName;

--- a/src/main/java/com/withus/withmebe/member/entity/Member.java
+++ b/src/main/java/com/withus/withmebe/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.withus.withmebe.member.entity;
 
 import static com.withus.withmebe.member.type.Membership.FREE;
+import static com.withus.withmebe.member.type.Role.ROLE_MEMBER;
 import static com.withus.withmebe.member.type.SignupPath.NORMAL;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -38,17 +39,18 @@ public class Member extends BaseEntity {
   @Column(unique = true, nullable = false)
   private String nickName;
 
-  private final LocalDate birthDate;
+  private LocalDate birthDate;
 
   @Enumerated(EnumType.STRING)
-  private final Gender gender;
+  private Gender gender;
 
   private String phoneNumber;
 
   private String profileImg;
 
   @Enumerated(EnumType.STRING)
-  private Role role;
+  @Column(nullable = false)
+  private Role role = ROLE_MEMBER;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
@@ -62,11 +64,13 @@ public class Member extends BaseEntity {
   private Membership membership = FREE;
 
   @Builder
-  public Member(Long memberId, String email, String password, LocalDate birthDate, Gender gender){
+  public Member(Long memberId, String email, String password, String nickName, LocalDate birthDate, Gender gender, LocalDateTime signupDttm){
     this.id = memberId;
     this.email = email;
     this.password = password;
+    this.nickName = nickName;
     this.birthDate = birthDate;
     this.gender = gender;
+    this.signupDttm = signupDttm;
   }
 }

--- a/src/main/java/com/withus/withmebe/member/entity/Member.java
+++ b/src/main/java/com/withus/withmebe/member/entity/Member.java
@@ -4,6 +4,7 @@ import static com.withus.withmebe.member.type.Membership.FREE;
 import static com.withus.withmebe.member.type.SignupPath.NORMAL;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.withus.withmebe.common.entity.BaseEntity;
 import com.withus.withmebe.member.type.Gender;
 import com.withus.withmebe.member.type.Membership;
 import com.withus.withmebe.member.type.Role;
@@ -23,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(force = true)
-public class Member {
+public class Member extends BaseEntity {
   @Id
   @GeneratedValue(strategy = IDENTITY)
   @Column(name = "member_id")

--- a/src/main/java/com/withus/withmebe/member/entity/Member.java
+++ b/src/main/java/com/withus/withmebe/member/entity/Member.java
@@ -1,0 +1,71 @@
+package com.withus.withmebe.member.entity;
+
+import static com.withus.withmebe.member.type.Membership.FREE;
+import static com.withus.withmebe.member.type.SignupPath.NORMAL;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import com.withus.withmebe.member.type.Gender;
+import com.withus.withmebe.member.type.Membership;
+import com.withus.withmebe.member.type.Role;
+import com.withus.withmebe.member.type.SignupPath;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(force = true)
+public class Member {
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "member_id")
+  private final Long id;
+
+  @Column(unique = true, nullable = false)
+  private final String email;
+
+  private String password;
+
+  @Column(unique = true, nullable = false)
+  private String nickName;
+
+  private final LocalDate birthDate;
+
+  @Enumerated(EnumType.STRING)
+  private final Gender gender;
+
+  private String phoneNumber;
+
+  private String profileImg;
+
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private SignupPath signupPath = NORMAL;
+
+  @Column(nullable = false)
+  private LocalDateTime signupDttm;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Membership membership = FREE;
+
+  @Builder
+  public Member(Long memberId, String email, String password, LocalDate birthDate, Gender gender){
+    this.id = memberId;
+    this.email = email;
+    this.password = password;
+    this.birthDate = birthDate;
+    this.gender = gender;
+  }
+}

--- a/src/main/java/com/withus/withmebe/member/repository/MemberRepository.java
+++ b/src/main/java/com/withus/withmebe/member/repository/MemberRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
   boolean existsByEmail(String email);
+  boolean existsByNickName(String nickName);
 
   Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/withus/withmebe/member/repository/MemberRepository.java
+++ b/src/main/java/com/withus/withmebe/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.withus.withmebe.member.repository;
+
+import com.withus.withmebe.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+  boolean existsByEmail(String email);
+
+  Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/withus/withmebe/member/service/AuthService.java
+++ b/src/main/java/com/withus/withmebe/member/service/AuthService.java
@@ -1,10 +1,16 @@
 package com.withus.withmebe.member.service;
 
 import static com.withus.withmebe.common.exception.ExceptionCode.EMAIL_CONFLICT;
+import static com.withus.withmebe.common.exception.ExceptionCode.ENTITY_NOT_FOUND;
+import static com.withus.withmebe.common.exception.ExceptionCode.PASSWORD_MISMATCH;
 
 import com.withus.withmebe.common.exception.CustomException;
+import com.withus.withmebe.member.dto.SigninDto;
 import com.withus.withmebe.member.dto.SignupDto;
+import com.withus.withmebe.member.entity.Member;
 import com.withus.withmebe.member.repository.MemberRepository;
+import com.withus.withmebe.security.jwt.provider.TokenProvider;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -15,6 +21,7 @@ public class AuthService {
 
   private final MemberRepository memberRepository;
   private final PasswordEncoder passwordEncoder;
+  private final TokenProvider tokenProvider;
 
   public SignupDto.Response signup(SignupDto.Request request) {
     if (memberRepository.existsByEmail(request.email())) {
@@ -24,5 +31,15 @@ public class AuthService {
     return SignupDto.Response.fromEntity(memberRepository.save(request.toEntity(passwordEncoder)));
   }
 
+  public SigninDto.Response signin(SigninDto.Request request) {
+    Member member = memberRepository.findByEmail(request.email())
+        .orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
 
+    if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+      throw new CustomException(PASSWORD_MISMATCH);
+    }
+
+    return new SigninDto.Response(
+        tokenProvider.generateToken(member.getId().toString(), List.of(member.getRole().name())));
+  }
 }

--- a/src/main/java/com/withus/withmebe/member/service/AuthService.java
+++ b/src/main/java/com/withus/withmebe/member/service/AuthService.java
@@ -1,0 +1,28 @@
+package com.withus.withmebe.member.service;
+
+import static com.withus.withmebe.common.exception.ExceptionCode.EMAIL_CONFLICT;
+
+import com.withus.withmebe.common.exception.CustomException;
+import com.withus.withmebe.member.dto.SignupDto;
+import com.withus.withmebe.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+  private final MemberRepository memberRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public SignupDto.Response signup(SignupDto.Request request) {
+    if (memberRepository.existsByEmail(request.email())) {
+      throw new CustomException(EMAIL_CONFLICT);
+    }
+
+    return SignupDto.Response.fromEntity(memberRepository.save(request.toEntity(passwordEncoder)));
+  }
+
+
+}

--- a/src/main/java/com/withus/withmebe/member/service/AuthService.java
+++ b/src/main/java/com/withus/withmebe/member/service/AuthService.java
@@ -40,6 +40,7 @@ public class AuthService {
             request.toEntity(passwordEncoder.encode(request.password()), getUniqueNickName())));
   }
 
+  @Transactional(readOnly = true)
   public SigninDto.Response signin(SigninDto.Request request) {
     Member member = memberRepository.findByEmail(request.email())
         .orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));

--- a/src/main/java/com/withus/withmebe/member/service/AuthService.java
+++ b/src/main/java/com/withus/withmebe/member/service/AuthService.java
@@ -2,6 +2,7 @@ package com.withus.withmebe.member.service;
 
 import static com.withus.withmebe.common.exception.ExceptionCode.EMAIL_CONFLICT;
 import static com.withus.withmebe.common.exception.ExceptionCode.ENTITY_NOT_FOUND;
+import static com.withus.withmebe.common.exception.ExceptionCode.PASSWORD_CHK_MISMATCH;
 import static com.withus.withmebe.common.exception.ExceptionCode.PASSWORD_MISMATCH;
 
 import com.withus.withmebe.common.exception.CustomException;
@@ -11,9 +12,11 @@ import com.withus.withmebe.member.entity.Member;
 import com.withus.withmebe.member.repository.MemberRepository;
 import com.withus.withmebe.security.jwt.provider.TokenProvider;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,12 +26,18 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
   private final TokenProvider tokenProvider;
 
+  @Transactional
   public SignupDto.Response signup(SignupDto.Request request) {
+    if (!request.password().equals(request.passwordChk())){
+      throw new CustomException(PASSWORD_CHK_MISMATCH);
+    }
     if (memberRepository.existsByEmail(request.email())) {
       throw new CustomException(EMAIL_CONFLICT);
     }
 
-    return SignupDto.Response.fromEntity(memberRepository.save(request.toEntity(passwordEncoder)));
+    return SignupDto.Response.fromEntity(
+        memberRepository.save(
+            request.toEntity(passwordEncoder.encode(request.password()), getUniqueNickName())));
   }
 
   public SigninDto.Response signin(SigninDto.Request request) {
@@ -41,5 +50,13 @@ public class AuthService {
 
     return new SigninDto.Response(
         tokenProvider.generateToken(member.getId().toString(), List.of(member.getRole().name())));
+  }
+
+  private String getUniqueNickName(){
+    UUID uuid;
+    do{
+      uuid = UUID.randomUUID();
+    }while (memberRepository.existsByNickName(uuid.toString()));
+    return uuid.toString();
   }
 }

--- a/src/main/java/com/withus/withmebe/member/type/Gender.java
+++ b/src/main/java/com/withus/withmebe/member/type/Gender.java
@@ -1,0 +1,12 @@
+package com.withus.withmebe.member.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Gender {
+  MALE("남성"),
+  FEMALE("여성"),
+  NONE("없음");
+
+  private final String value;
+}

--- a/src/main/java/com/withus/withmebe/member/type/Membership.java
+++ b/src/main/java/com/withus/withmebe/member/type/Membership.java
@@ -1,0 +1,11 @@
+package com.withus.withmebe.member.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Membership {
+  FREE("무료"),
+  PREMIUM("프리미엄");
+
+  private final String value;
+}

--- a/src/main/java/com/withus/withmebe/member/type/Role.java
+++ b/src/main/java/com/withus/withmebe/member/type/Role.java
@@ -1,0 +1,11 @@
+package com.withus.withmebe.member.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Role {
+  ROLE_ADMIN("관리자"),
+  ROLE_MEMBER("회원");
+
+  private final String value;
+}

--- a/src/main/java/com/withus/withmebe/member/type/SignupPath.java
+++ b/src/main/java/com/withus/withmebe/member/type/SignupPath.java
@@ -1,0 +1,11 @@
+package com.withus.withmebe.member.type;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SignupPath {
+  NORMAL("일반회원가입"),
+  KAKAO("카카오");
+
+  private final String value;
+}

--- a/src/main/java/com/withus/withmebe/security/config/SecurityConfig.java
+++ b/src/main/java/com/withus/withmebe/security/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.withus.withmebe.security.config;
+
+import com.withus.withmebe.security.jwt.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final JwtAuthenticationFilter authenticationFilter;
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .csrf(csrf -> csrf.disable())
+        .sessionManagement(sessionManagement ->
+            sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(authorizeRequests ->
+            authorizeRequests.requestMatchers("/api/auth/signup", "/api/auth/signin").permitAll()
+                .anyRequest().authenticated())
+        .addFilterBefore(this.authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/withus/withmebe/security/domain/CustomUserDetails.java
+++ b/src/main/java/com/withus/withmebe/security/domain/CustomUserDetails.java
@@ -1,0 +1,52 @@
+package com.withus.withmebe.security.domain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+  private final transient UserDetailsDomain details;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    Collection<GrantedAuthority> list = new ArrayList<>();
+    list.add(new SimpleGrantedAuthority(details.role().name()));
+    return list;
+  }
+
+  @Override
+  public String getPassword() {
+    return details.password();
+  }
+
+  @Override
+  public String getUsername() {
+    return details.id().toString();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+}

--- a/src/main/java/com/withus/withmebe/security/domain/UserDetailsDomain.java
+++ b/src/main/java/com/withus/withmebe/security/domain/UserDetailsDomain.java
@@ -1,0 +1,26 @@
+package com.withus.withmebe.security.domain;
+
+import com.withus.withmebe.member.entity.Member;
+import com.withus.withmebe.member.type.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserDetailsDomain(
+    @NotNull
+    Long id,
+
+    @NotBlank
+    String password,
+
+    @NotNull
+    Role role
+) {
+
+  public static UserDetailsDomain fromEntity(Member member) {
+    return new UserDetailsDomain(
+        member.getId(),
+        member.getPassword(),
+        member.getRole()
+    );
+  }
+}

--- a/src/main/java/com/withus/withmebe/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/withus/withmebe/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.withus.withmebe.security.jwt.filter;
+
+import com.withus.withmebe.security.jwt.provider.TokenProvider;
+import com.withus.withmebe.security.util.MySecurityUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  public static final String TOKEN_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
+
+  private final TokenProvider tokenProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String token = this.resolveTokenFromRequest(request);
+    // 토큰 유효성 검증
+    if (StringUtils.hasText(token) && this.tokenProvider.validateToken(token)) {
+      // 시큐리티 컨텍스트에 인증정보를 넣어줌
+      SecurityContextHolder.getContext().setAuthentication(
+          this.tokenProvider.getAuthentication(token));
+
+      log.info("[{}] -> {}",
+          MySecurityUtil.getCustomUserDetails().getUsername(), request.getRequestURI());
+    }
+    // 필터가 연속적으로 되도록
+    filterChain.doFilter(request, response);
+  }
+
+  private String resolveTokenFromRequest(HttpServletRequest request) {
+    String token = request.getHeader(TOKEN_HEADER);
+
+    if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+      return token.substring(TOKEN_PREFIX.length());
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/withus/withmebe/security/jwt/provider/TokenProvider.java
+++ b/src/main/java/com/withus/withmebe/security/jwt/provider/TokenProvider.java
@@ -1,0 +1,80 @@
+package com.withus.withmebe.security.jwt.provider;
+
+import static com.withus.withmebe.common.exception.ExceptionCode.TOKEN_EXPIRED;
+
+import com.withus.withmebe.common.exception.CustomException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+  private static final long TOKEN_EXPIRE_TIME = 3_600_000; // 1000 * 60 * 60 // 1hour
+  private static final String KEY_ROLES = "roles";
+  private final UserDetailsService userDetailsService;
+  private SecretKey key;
+  @Value("${spring.jwt.secret}")
+  private String secretKey;
+
+  public String generateToken(String username, List<String> roles) {
+    Claims claims = Jwts.claims().subject(username).add(KEY_ROLES, roles).build();
+
+    Date now = new Date();
+    Date expiredDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME);
+
+    return Jwts.builder()
+        .claims(claims)
+        .issuedAt(now)
+        .expiration(expiredDate)
+        .signWith(key, SIG.HS256)
+        .compact();
+  }
+
+  public Authentication getAuthentication(String token) {
+    UserDetails userDetails = this.userDetailsService.loadUserByUsername(this.getUsername(token));
+    return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+  }
+
+  public boolean validateToken(String token) {
+    if (!StringUtils.hasText(token)) {
+      throw new CustomException(TOKEN_EXPIRED);
+    }
+
+    var claims = this.parseClaims(token);
+    return !claims.getExpiration().before(new Date());
+  }
+
+  private String getUsername(String token) {
+    return this.parseClaims(token).getSubject();
+  }
+
+  private Claims parseClaims(String token) {
+    try {
+      return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+    } catch (ExpiredJwtException e) {
+      return e.getClaims();
+    }
+  }
+
+  @PostConstruct
+  private void setKey() {
+    key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(this.secretKey));
+  }
+}

--- a/src/main/java/com/withus/withmebe/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/withus/withmebe/security/service/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.withus.withmebe.security.service;
+
+import com.withus.withmebe.common.exception.ExceptionCode;
+import com.withus.withmebe.member.repository.MemberRepository;
+import com.withus.withmebe.security.domain.CustomUserDetails;
+import com.withus.withmebe.security.domain.UserDetailsDomain;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    return new CustomUserDetails(getUserDetailsDomain(username));
+  }
+
+  private UserDetailsDomain getUserDetailsDomain(String username) {
+    return UserDetailsDomain.fromEntity(memberRepository.findById(Long.valueOf(username))
+        .orElseThrow(() -> new UsernameNotFoundException(
+            ExceptionCode.ENTITY_NOT_FOUND.getMessage()
+        )));
+  }
+}

--- a/src/main/java/com/withus/withmebe/security/util/MySecurityUtil.java
+++ b/src/main/java/com/withus/withmebe/security/util/MySecurityUtil.java
@@ -1,0 +1,20 @@
+package com.withus.withmebe.security.util;
+
+import static com.withus.withmebe.common.exception.ExceptionCode.AUTHENTICATION_ISSUE;
+
+import com.withus.withmebe.common.exception.CustomException;
+import com.withus.withmebe.security.domain.CustomUserDetails;
+import lombok.experimental.UtilityClass;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@UtilityClass
+public class MySecurityUtil {
+
+  public static CustomUserDetails getCustomUserDetails() {
+    Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    if (!(principal instanceof CustomUserDetails)) {
+      throw new CustomException(AUTHENTICATION_ISSUE);
+    }
+    return (CustomUserDetails) principal;
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,6 @@
 spring:
+  jwt:
+    secret: ZGF5b25lLXNwcmluZy1ib290LWRpdmlkZW5kLXByb2plY3QtdHV0b3JpYWwtand0LXNlY3JldC1rZXkK
   jpa:
     generate-ddl: false
     show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  jwt:
+    secret: ZGF5b25lLXNwcmluZy1ib290LWRpdmlkZW5kLXByb2plY3QtdHV0b3JpYWwtand0LXNlY3JldC1rZXkK
   jpa:
     generate-ddl: false
     show-sql: true

--- a/src/test/http/auth.http
+++ b/src/test/http/auth.http
@@ -1,0 +1,20 @@
+### 회원가입
+POST http://localhost:8080/api/auth/signup
+Content-Type: application/json
+
+{
+  "email": "example1@example.com",
+  "password": "password123",
+  "passwordChk": "password123",
+  "birthDate": "1990-01-01",
+  "gender": "MALE"
+}
+
+### 로그인
+POST http://localhost:8080/api/auth/signin
+Content-Type: application/json
+
+{
+  "email": "example@example.com",
+  "password": "password123"
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 회원 시작

**TO-BE**
- 시큐리티 + jwt 적용
- 회원가입
  - 비밀번호랑 비밀번호 확인 이랑 동일한체 체크
  - email 중복 체크
  - 중복안되는 닉네임 임의 설정
  - 비밀번호는 시큐리티의 PasswordEncoder로 encode 설정
- 로그인
  - 이메일, 비밀번호를 받고 해당하는 유저가 있으면 access token 발급
- BaseEntity 추가
- dependency
  - 타임리프 dependency 제거
  - jwt dependency 변경

### 테스트
- [X] 테스트 코드