### PR TITLE
🔀 Merge Feature/comment:  comment 코드 리팩토링 및 테스트 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
 	// aws
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// test
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
+++ b/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,8 +26,8 @@ public class CommentController {
 
   private final CommentService commentService;
 
-  @PostMapping("/add/{gatheringId}")
-  public ResponseEntity<CommentResponse> addComment(@PathVariable long gatheringId,
+  @PostMapping({"/add", "add?gatheringid={gatheringid}"})
+  public ResponseEntity<CommentResponse> addComment(@RequestParam(value = "gatheringid") long gatheringId,
       @RequestBody AddCommentRequest request) {
     return ResponseEntity.ok(commentService.createComment(gatheringId, request));
   }

--- a/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
+++ b/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.withus.withmebe.comment.dto.request.SetCommentRequest;
 import com.withus.withmebe.comment.dto.response.CommentResponse;
 import com.withus.withmebe.comment.service.CommentService;
 import com.withus.withmebe.security.domain.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +33,7 @@ public class CommentController {
   public ResponseEntity<CommentResponse> addComment(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @RequestParam(value = "gatheringid") long gatheringId,
-      @RequestBody AddCommentRequest request) {
+      @Valid @RequestBody AddCommentRequest request) {
     return ResponseEntity.ok(
         commentService.createComment(customUserDetails.getMemberId(), gatheringId, request));
   }
@@ -46,7 +47,7 @@ public class CommentController {
   @PutMapping("/{commentId}")
   public ResponseEntity<CommentResponse> setComment(
       @AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable long commentId,
-      @RequestBody SetCommentRequest request) {
+      @Valid @RequestBody SetCommentRequest request) {
     return ResponseEntity.ok(
         commentService.updateComment(customUserDetails.getMemberId(), commentId, request));
   }

--- a/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
+++ b/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
@@ -4,11 +4,13 @@ import com.withus.withmebe.comment.dto.request.AddCommentRequest;
 import com.withus.withmebe.comment.dto.request.SetCommentRequest;
 import com.withus.withmebe.comment.dto.response.CommentResponse;
 import com.withus.withmebe.comment.service.CommentService;
+import com.withus.withmebe.security.domain.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,9 +29,12 @@ public class CommentController {
   private final CommentService commentService;
 
   @PostMapping({"/add", "add?gatheringid={gatheringid}"})
-  public ResponseEntity<CommentResponse> addComment(@RequestParam(value = "gatheringid") long gatheringId,
+  public ResponseEntity<CommentResponse> addComment(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails,
+      @RequestParam(value = "gatheringid") long gatheringId,
       @RequestBody AddCommentRequest request) {
-    return ResponseEntity.ok(commentService.createComment(gatheringId, request));
+    return ResponseEntity.ok(
+        commentService.createComment(customUserDetails.getMemberId(), gatheringId, request));
   }
 
   @GetMapping("/list/{gatheringId}")
@@ -39,13 +44,17 @@ public class CommentController {
   }
 
   @PutMapping("/{commentId}")
-  public ResponseEntity<CommentResponse> setComment(@PathVariable long commentId,
+  public ResponseEntity<CommentResponse> setComment(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable long commentId,
       @RequestBody SetCommentRequest request) {
-    return ResponseEntity.ok(commentService.updateComment(commentId, request));
+    return ResponseEntity.ok(
+        commentService.updateComment(customUserDetails.getMemberId(), commentId, request));
   }
 
   @DeleteMapping("/{commentId}")
-  public ResponseEntity<CommentResponse> removeComment(@PathVariable long commentId) {
-    return ResponseEntity.ok(commentService.deleteComment(commentId));
+  public ResponseEntity<CommentResponse> removeComment(
+      @AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable long commentId) {
+    return ResponseEntity.ok(
+        commentService.deleteComment(customUserDetails.getMemberId(), commentId));
   }
 }

--- a/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
+++ b/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
@@ -29,7 +29,7 @@ public class CommentController {
 
   private final CommentService commentService;
 
-  @PostMapping({"/add", "add?gatheringid={gatheringid}"})
+  @PostMapping({"/add"})
   public ResponseEntity<CommentResponse> addComment(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @RequestParam(value = "gatheringid") long gatheringId,

--- a/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
+++ b/src/main/java/com/withus/withmebe/comment/controller/CommentController.java
@@ -29,7 +29,7 @@ public class CommentController {
 
   private final CommentService commentService;
 
-  @PostMapping({"/add"})
+  @PostMapping("/add")
   public ResponseEntity<CommentResponse> addComment(
       @AuthenticationPrincipal CustomUserDetails customUserDetails,
       @RequestParam(value = "gatheringid") long gatheringId,

--- a/src/main/java/com/withus/withmebe/comment/dto/request/AddCommentRequest.java
+++ b/src/main/java/com/withus/withmebe/comment/dto/request/AddCommentRequest.java
@@ -2,8 +2,11 @@ package com.withus.withmebe.comment.dto.request;
 
 import com.withus.withmebe.comment.entity.Comment;
 import com.withus.withmebe.member.entity.Member;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 public record AddCommentRequest(
+    @NotBlank
     String commentContent
 ) {
 

--- a/src/main/java/com/withus/withmebe/comment/dto/request/AddCommentRequest.java
+++ b/src/main/java/com/withus/withmebe/comment/dto/request/AddCommentRequest.java
@@ -3,7 +3,6 @@ package com.withus.withmebe.comment.dto.request;
 import com.withus.withmebe.comment.entity.Comment;
 import com.withus.withmebe.member.entity.Member;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 public record AddCommentRequest(
     @NotBlank

--- a/src/main/java/com/withus/withmebe/comment/dto/request/AddCommentRequest.java
+++ b/src/main/java/com/withus/withmebe/comment/dto/request/AddCommentRequest.java
@@ -9,10 +9,10 @@ public record AddCommentRequest(
     String commentContent
 ) {
 
-  public Comment toEntity(Long gatheringId, Member member) {
+  public Comment toEntity(Long gatheringId, Member requester) {
     return Comment.builder()
         .gatheringId(gatheringId)
-        .member(member)
+        .writer(requester)
         .commentContent(this.commentContent)
         .build();
   }

--- a/src/main/java/com/withus/withmebe/comment/dto/request/SetCommentRequest.java
+++ b/src/main/java/com/withus/withmebe/comment/dto/request/SetCommentRequest.java
@@ -1,6 +1,10 @@
 package com.withus.withmebe.comment.dto.request;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 public record SetCommentRequest(
+    @NotBlank
     String commentContent
 ) {
 

--- a/src/main/java/com/withus/withmebe/comment/dto/request/SetCommentRequest.java
+++ b/src/main/java/com/withus/withmebe/comment/dto/request/SetCommentRequest.java
@@ -1,7 +1,6 @@
 package com.withus.withmebe.comment.dto.request;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 public record SetCommentRequest(
     @NotBlank

--- a/src/main/java/com/withus/withmebe/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/withus/withmebe/comment/dto/response/CommentResponse.java
@@ -1,6 +1,5 @@
 package com.withus.withmebe.comment.dto.response;
 
-import com.withus.withmebe.comment.entity.Comment;
 import java.time.LocalDateTime;
 import lombok.Builder;
 

--- a/src/main/java/com/withus/withmebe/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/withus/withmebe/comment/dto/response/CommentResponse.java
@@ -10,18 +10,7 @@ public record CommentResponse(
     String nickName,
     String commentContent,
     LocalDateTime createdDttm,
-    LocalDateTime updatedDttm,
-    LocalDateTime deletedDttm
+    LocalDateTime updatedDttm
 ) {
 
-
-  public static CommentResponse fromEntity(Comment comment) {
-    return CommentResponse.builder()
-        .id(comment.getId())
-        .nickName(comment.getMember().getNickName())
-        .commentContent(comment.getCommentContent())
-        .createdDttm(comment.getCreatedDttm())
-        .updatedDttm(comment.getUpdatedDttm())
-        .build();
-  }
 }

--- a/src/main/java/com/withus/withmebe/comment/entity/Comment.java
+++ b/src/main/java/com/withus/withmebe/comment/entity/Comment.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -29,13 +30,15 @@ public class Comment extends BaseEntity {
   @Column(name = "comment_id")
   private Long id;
 
+  @Column(nullable = false)
   private Long gatheringId;
 
   @ManyToOne
-  @JoinColumn(name = "member_id")
+  @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
   @Setter
+  @Column(nullable = false)
   private String commentContent;
 
   @Builder

--- a/src/main/java/com/withus/withmebe/comment/entity/Comment.java
+++ b/src/main/java/com/withus/withmebe/comment/entity/Comment.java
@@ -34,23 +34,23 @@ public class Comment extends BaseEntity {
 
   @ManyToOne
   @JoinColumn(name = "member_id", nullable = false)
-  private Member member;
+  private Member writer;
 
   @Setter
   @Column(nullable = false)
   private String commentContent;
 
   @Builder
-  public Comment(Long gatheringId, Member member, String commentContent) {
+  public Comment(Long gatheringId, Member writer, String commentContent) {
     this.gatheringId = gatheringId;
-    this.member = member;
+    this.writer = writer;
     this.commentContent = commentContent;
   }
 
   public CommentResponse toResponse() {
     return CommentResponse.builder()
         .id(this.id)
-        .nickName(this.member.getNickName())
+        .nickName(this.writer.getNickName())
         .commentContent(this.commentContent)
         .createdDttm(this.getCreatedDttm())
         .updatedDttm(this.getUpdatedDttm())

--- a/src/main/java/com/withus/withmebe/comment/entity/Comment.java
+++ b/src/main/java/com/withus/withmebe/comment/entity/Comment.java
@@ -56,4 +56,8 @@ public class Comment extends BaseEntity {
         .updatedDttm(this.getUpdatedDttm())
         .build();
   }
+
+  public boolean isWriter(long requesterId) {
+    return this.writer.getId() == requesterId;
+  }
 }

--- a/src/main/java/com/withus/withmebe/comment/entity/Comment.java
+++ b/src/main/java/com/withus/withmebe/comment/entity/Comment.java
@@ -14,7 +14,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 

--- a/src/main/java/com/withus/withmebe/comment/entity/Comment.java
+++ b/src/main/java/com/withus/withmebe/comment/entity/Comment.java
@@ -5,6 +5,7 @@ import com.withus.withmebe.common.entity.BaseEntity;
 import com.withus.withmebe.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,7 +33,7 @@ public class Comment extends BaseEntity {
   @Column(nullable = false)
   private Long gatheringId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
   private Member writer;
 
@@ -57,7 +58,7 @@ public class Comment extends BaseEntity {
         .build();
   }
 
-  public boolean isWriter(long requesterId) {
-    return this.writer.getId() == requesterId;
+  public boolean isWriter(long memberId) {
+    return this.writer.getId() == memberId;
   }
 }

--- a/src/main/java/com/withus/withmebe/comment/entity/Comment.java
+++ b/src/main/java/com/withus/withmebe/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.withus.withmebe.comment.entity;
 
+import com.withus.withmebe.comment.dto.response.CommentResponse;
 import com.withus.withmebe.common.entity.BaseEntity;
 import com.withus.withmebe.member.entity.Member;
 import jakarta.persistence.Column;
@@ -42,5 +43,15 @@ public class Comment extends BaseEntity {
     this.gatheringId = gatheringId;
     this.member = member;
     this.commentContent = commentContent;
+  }
+
+  public CommentResponse toResponse() {
+    return CommentResponse.builder()
+        .id(this.id)
+        .nickName(this.member.getNickName())
+        .commentContent(this.commentContent)
+        .createdDttm(this.getCreatedDttm())
+        .updatedDttm(this.getUpdatedDttm())
+        .build();
   }
 }

--- a/src/main/java/com/withus/withmebe/comment/repository/CommentRepository.java
+++ b/src/main/java/com/withus/withmebe/comment/repository/CommentRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/com/withus/withmebe/comment/repository/CommentRepository.java
+++ b/src/main/java/com/withus/withmebe/comment/repository/CommentRepository.java
@@ -3,6 +3,7 @@ package com.withus.withmebe.comment.repository;
 import com.withus.withmebe.comment.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-  @Query(value = "select c from Comment c join fetch c.member where c.gatheringId = :gatheringId", countQuery = "select count(c) from Comment c where c.gatheringId = :gatheringId")
+  @EntityGraph(attributePaths = "member")
   Page<Comment> findCommentsByGatheringId(long gatheringId, Pageable pageable);
 
 }

--- a/src/main/java/com/withus/withmebe/comment/repository/CommentRepository.java
+++ b/src/main/java/com/withus/withmebe/comment/repository/CommentRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-  @EntityGraph(attributePaths = "member")
+  @EntityGraph(attributePaths = "writer")
   Page<Comment> findCommentsByGatheringId(long gatheringId, Pageable pageable);
 
 }

--- a/src/main/java/com/withus/withmebe/comment/service/CommentService.java
+++ b/src/main/java/com/withus/withmebe/comment/service/CommentService.java
@@ -30,7 +30,7 @@ public class CommentService {
 
     Member requester = readRequester(requesterId);
     Comment newComment = commentRepository.save(request.toEntity(gatheringId, requester));
-    return CommentResponse.fromEntity(newComment);
+    return newComment.toResponse();
   }
 
   @Transactional(readOnly = true)
@@ -38,7 +38,7 @@ public class CommentService {
 
     Pageable adjustedPageable = adjustPageable(pageable);
     Page<Comment> comments = commentRepository.findCommentsByGatheringId(gatheringId, adjustedPageable);
-    return comments.map(CommentResponse::fromEntity);
+    return comments.map(Comment::toResponse);
   }
 
   private Pageable adjustPageable(Pageable pageable) {
@@ -55,7 +55,7 @@ public class CommentService {
 
     comment.setCommentContent(request.commentContent());
     Comment updatedComment = readComment(commentId);
-    return CommentResponse.fromEntity(updatedComment);
+    return updatedComment.toResponse();
   }
 
   public CommentResponse deleteComment(long requesterId, long commentId) {
@@ -63,7 +63,7 @@ public class CommentService {
     Comment comment = readEditableComment(requesterId, commentId);
 
     commentRepository.delete(comment);
-    return CommentResponse.fromEntity(comment);
+    return comment.toResponse();
   }
 
   private Comment readEditableComment(long requesterId, long commentId) {

--- a/src/main/java/com/withus/withmebe/comment/service/CommentService.java
+++ b/src/main/java/com/withus/withmebe/comment/service/CommentService.java
@@ -73,7 +73,7 @@ public class CommentService {
   private Comment readEditableComment(long requesterId, long commentId) {
 
     Comment comment = readComment(commentId);
-    if (comment.getWriter().getId() != requesterId) {
+    if (!comment.isWriter(requesterId)) {
       throw new CustomException(AUTHORIZATION_ISSUE);
     }
     return comment;

--- a/src/main/java/com/withus/withmebe/comment/service/CommentService.java
+++ b/src/main/java/com/withus/withmebe/comment/service/CommentService.java
@@ -9,6 +9,7 @@ import com.withus.withmebe.comment.entity.Comment;
 import com.withus.withmebe.comment.repository.CommentRepository;
 import com.withus.withmebe.comment.dto.request.AddCommentRequest;
 import com.withus.withmebe.common.exception.CustomException;
+import com.withus.withmebe.gathering.repository.GatheringRepository;
 import com.withus.withmebe.member.entity.Member;
 import com.withus.withmebe.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,11 +25,14 @@ public class CommentService {
 
   private final CommentRepository commentRepository;
   private final MemberRepository memberRepository;
+  private final GatheringRepository gatheringRepository;
 
   @Transactional
   public CommentResponse createComment(long requesterId, long gatheringId, AddCommentRequest request) {
 
     Member requester = readRequester(requesterId);
+    checkGatheringExist(gatheringId);
+
     Comment newComment = commentRepository.save(request.toEntity(gatheringId, requester));
     return newComment.toResponse();
   }
@@ -83,5 +87,11 @@ public class CommentService {
   private Member readRequester(long requesterId) {
     return memberRepository.findById(requesterId)
         .orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
+  }
+
+  private void checkGatheringExist(long gatheringId) {
+    if(!gatheringRepository.existsById(gatheringId)) {
+      throw new CustomException(ENTITY_NOT_FOUND);
+    }
   }
 }

--- a/src/main/java/com/withus/withmebe/comment/service/CommentService.java
+++ b/src/main/java/com/withus/withmebe/comment/service/CommentService.java
@@ -59,7 +59,6 @@ public class CommentService {
     return CommentResponse.fromEntity(updatedComment);
   }
 
-  @Transactional
   public CommentResponse deleteComment(long commentId) {
 
     Comment comment = readEditableComment(commentId);

--- a/src/main/java/com/withus/withmebe/comment/service/CommentService.java
+++ b/src/main/java/com/withus/withmebe/comment/service/CommentService.java
@@ -73,7 +73,7 @@ public class CommentService {
   private Comment readEditableComment(long requesterId, long commentId) {
 
     Comment comment = readComment(commentId);
-    if (comment.getMember().getId() != requesterId) {
+    if (comment.getWriter().getId() != requesterId) {
       throw new CustomException(AUTHORIZATION_ISSUE);
     }
     return comment;

--- a/src/test/java/com/withus/withmebe/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/withus/withmebe/comment/controller/CommentControllerTest.java
@@ -3,19 +3,19 @@ package com.withus.withmebe.comment.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.withus.withmebe.comment.dto.response.CommentResponse;
 import com.withus.withmebe.comment.service.CommentService;
+import com.withus.withmebe.common.exception.CustomException;
+import com.withus.withmebe.common.exception.ExceptionCode;
 import com.withus.withmebe.security.jwt.filter.JwtAuthenticationFilter;
 import java.time.LocalDateTime;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -26,8 +26,6 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 import util.WithMockCustomUser;
 
 
@@ -42,37 +40,27 @@ class CommentControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
-  @Autowired
-  private WebApplicationContext context;
-
-  @Autowired
-  private ObjectMapper objectMapper;
-
   private final String baseUrl = "/api/comment";
   private final Gson gson = new Gson();
+  private static final JsonObject jsonObject = new JsonObject();
 
   private final CommentResponse commentResponse = CommentResponse.builder()
       .id(1L)
       .nickName("홍길동")
       .commentContent("내용")
-      .createdDttm(LocalDateTime.of(2021,2,3,4,5,6))
-      .updatedDttm(LocalDateTime.of(2022,3,4,5,6,7))
+      .createdDttm(LocalDateTime.of(2021, 2, 3, 4, 5, 6))
+      .updatedDttm(LocalDateTime.of(2022, 3, 4, 5, 6, 7))
       .build();
 
-  @BeforeEach
-  public void setUp() {
-    mockMvc = MockMvcBuilders
-        .webAppContextSetup(context)
-        .apply(springSecurity())
-        .build();
+  @BeforeAll
+  static void setUp() {
+    jsonObject.addProperty("commentContent", "아무내용");
   }
 
   @Test
   @WithMockCustomUser
   void seccessToAddComment() throws Exception {
     //given
-    JsonObject jsonObject = new JsonObject();
-    jsonObject.addProperty("commentContent", "아무내용");
     given(commentService.createComment(anyLong(), anyLong(), any()))
         .willReturn(commentResponse);
 
@@ -86,7 +74,53 @@ class CommentControllerTest {
         .andExpect(jsonPath("$.id").value(commentResponse.id()))
         .andExpect(jsonPath("$.nickName").value(commentResponse.nickName()))
         .andExpect(jsonPath("$.commentContent").value(commentResponse.commentContent()))
-        .andExpect(jsonPath("$.createdDttm").value(commentResponse.createdDttm()))
-        .andExpect(jsonPath("$.updatedDttm").value(commentResponse.updatedDttm()));
+        .andExpect(jsonPath("$.createdDttm").value(commentResponse.createdDttm().toString()))
+        .andExpect(jsonPath("$.updatedDttm").value(commentResponse.updatedDttm().toString()));
   }
+
+  @Test
+  @WithMockCustomUser
+  void failToAddCommentByBadRequest() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(post(baseUrl + "/add")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(gson.toJson(jsonObject))
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockCustomUser
+  void failToAddCommentByNotFound() throws Exception {
+    //given
+    given(commentService.createComment(anyLong(), anyLong(), any()))
+        .willThrow(new CustomException(ExceptionCode.ENTITY_NOT_FOUND));
+
+    //when
+    //then
+    mockMvc.perform(post(baseUrl + "/add?gatheringid=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(gson.toJson(jsonObject))
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockCustomUser
+  void failToAddCommentByAuthenticationIssue() throws Exception {
+    //given
+    given(commentService.createComment(anyLong(), anyLong(), any()))
+        .willThrow(new CustomException(ExceptionCode.AUTHENTICATION_ISSUE));
+
+    //when
+    //then
+    mockMvc.perform(post(baseUrl + "/add?gatheringid=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(gson.toJson(jsonObject))
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
 }

--- a/src/test/java/com/withus/withmebe/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/withus/withmebe/comment/controller/CommentControllerTest.java
@@ -1,0 +1,92 @@
+package com.withus.withmebe.comment.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.withus.withmebe.comment.dto.response.CommentResponse;
+import com.withus.withmebe.comment.service.CommentService;
+import com.withus.withmebe.security.jwt.filter.JwtAuthenticationFilter;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import util.WithMockCustomUser;
+
+
+@WebMvcTest(controllers = CommentController.class, excludeFilters = {
+    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class)})
+@MockBean(JpaMetamodelMappingContext.class)
+class CommentControllerTest {
+
+  @MockBean
+  private CommentService commentService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private final String baseUrl = "/api/comment";
+  private final Gson gson = new Gson();
+
+  private final CommentResponse commentResponse = CommentResponse.builder()
+      .id(1L)
+      .nickName("홍길동")
+      .commentContent("내용")
+      .createdDttm(LocalDateTime.of(2021,2,3,4,5,6))
+      .updatedDttm(LocalDateTime.of(2022,3,4,5,6,7))
+      .build();
+
+  @BeforeEach
+  public void setUp() {
+    mockMvc = MockMvcBuilders
+        .webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+  }
+
+  @Test
+  @WithMockCustomUser
+  void seccessToAddComment() throws Exception {
+    //given
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("commentContent", "아무내용");
+    given(commentService.createComment(anyLong(), anyLong(), any()))
+        .willReturn(commentResponse);
+
+    //when
+    //then
+    mockMvc.perform(post(baseUrl + "/add?gatheringid=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(gson.toJson(jsonObject))
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(commentResponse.id()))
+        .andExpect(jsonPath("$.nickName").value(commentResponse.nickName()))
+        .andExpect(jsonPath("$.commentContent").value(commentResponse.commentContent()))
+        .andExpect(jsonPath("$.createdDttm").value(commentResponse.createdDttm()))
+        .andExpect(jsonPath("$.updatedDttm").value(commentResponse.updatedDttm()));
+  }
+}

--- a/src/test/java/com/withus/withmebe/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/withus/withmebe/comment/controller/CommentControllerTest.java
@@ -3,6 +3,7 @@ package com.withus.withmebe.comment.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -15,6 +16,7 @@ import com.withus.withmebe.common.exception.CustomException;
 import com.withus.withmebe.common.exception.ExceptionCode;
 import com.withus.withmebe.security.jwt.filter.JwtAuthenticationFilter;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,8 +24,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import util.WithMockCustomUser;
@@ -41,6 +47,7 @@ class CommentControllerTest {
   private MockMvc mockMvc;
 
   private final String baseUrl = "/api/comment";
+  private final long gatheringId = 1L;
   private final Gson gson = new Gson();
   private static final JsonObject jsonObject = new JsonObject();
 
@@ -113,7 +120,6 @@ class CommentControllerTest {
     //given
     given(commentService.createComment(anyLong(), anyLong(), any()))
         .willThrow(new CustomException(ExceptionCode.AUTHENTICATION_ISSUE));
-
     //when
     //then
     mockMvc.perform(post(baseUrl + "/add?gatheringid=1")
@@ -123,4 +129,53 @@ class CommentControllerTest {
         .andExpect(status().isUnauthorized());
   }
 
+  @Test
+  @WithMockUser
+  void seccessToGetComments() throws Exception {
+    //given
+    CommentResponse commentResponse2 = CommentResponse.builder()
+        .id(2L)
+        .nickName("홍길동2")
+        .commentContent("내용2")
+        .createdDttm(LocalDateTime.of(2023, 4, 5, 6, 7, 8))
+        .updatedDttm(LocalDateTime.of(2024, 5, 6, 7, 8, 9))
+        .build();
+    Pageable pageable = PageRequest.of(0, 10);
+
+    given(commentService.readComments(anyLong(), any()))
+        .willReturn(
+            new PageImpl<CommentResponse>(List.of(commentResponse, commentResponse2), pageable, 2));
+
+    //when
+    //then
+    mockMvc.perform(get(baseUrl + "/list/" + gatheringId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.totalElements").value(2))
+        .andExpect(jsonPath("$.totalPages").value(1))
+        .andExpect(jsonPath("$.pageable.pageNumber").value(0))
+        .andExpect(jsonPath("$.content[0].id").value(commentResponse.id()))
+        .andExpect(jsonPath("$.content[0].nickName").value(commentResponse.nickName()))
+        .andExpect(jsonPath("$.content[0].commentContent").value(commentResponse.commentContent()))
+        .andExpect(jsonPath("$.content[0].createdDttm").value(commentResponse.createdDttm().toString()))
+        .andExpect(jsonPath("$.content[0].updatedDttm").value(commentResponse.updatedDttm().toString()))
+        .andExpect(jsonPath("$.content[1].id").value(commentResponse2.id()))
+        .andExpect(jsonPath("$.content[1].nickName").value(commentResponse2.nickName()))
+        .andExpect(jsonPath("$.content[1].commentContent").value(commentResponse2.commentContent()))
+        .andExpect(jsonPath("$.content[1].createdDttm").value(commentResponse2.createdDttm().toString()))
+        .andExpect(jsonPath("$.content[1].updatedDttm").value(commentResponse2.updatedDttm().toString()));
+  }
+
+  @Test
+  @WithMockUser
+  void failToGetCommentsByBadRequest() throws Exception {
+    //given
+    //when
+    //then
+    mockMvc.perform(get(baseUrl + "/list")
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isBadRequest());
+  }
 }

--- a/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
@@ -38,6 +38,7 @@ class CommentRepositoryTest {
 
     assertEquals(2, comments.getTotalElements());
     assertEquals(1, comments.getTotalPages());
+    assertEquals(0, comments.getNumber());
 
     Comment comment1 = comments.getContent().get(0);
     assertEquals(1L, comment1.getId());

--- a/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
@@ -4,9 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.withus.withmebe.comment.entity.Comment;
-import com.withus.withmebe.member.entity.Member;
 import com.withus.withmebe.member.repository.MemberRepository;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -29,13 +27,10 @@ class CommentRepositoryTest {
   @Autowired
   private CommentRepository commentRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
-
   private final long gatheringId = 1L;
 
   @Test
-  void readCommentsByGatheringId() {
+  void testToReadCommentsByGatheringId() {
     //given
 
     Pageable pageable = PageRequest.of(0,10);
@@ -47,23 +42,23 @@ class CommentRepositoryTest {
     assertEquals(2, comments.getTotalElements());
     assertEquals(1, comments.getTotalPages());
 
-    Comment pageElement1 = comments.getContent().get(0);
-    assertTrue(pageElement1.getId() != null && pageElement1.getId() > 0);
-    assertEquals(gatheringId, pageElement1.getGatheringId());
-    assertEquals(1L, pageElement1.getMember().getId());
-    assertEquals("첫 번째 댓글입니다.", pageElement1.getCommentContent());
-    assertNotNull(pageElement1.getCreatedDttm());
-    assertNotNull(pageElement1.getUpdatedDttm());
-    assertNull(pageElement1.getDeletedDttm());
+    Comment comment1 = comments.getContent().get(0);
+    assertEquals(1L, comment1.getId());
+    assertEquals(gatheringId, comment1.getGatheringId());
+    assertEquals(1L, comment1.getMember().getId());
+    assertEquals("comment1", comment1.getCommentContent());
+    assertNotNull(comment1.getCreatedDttm());
+    assertNotNull(comment1.getUpdatedDttm());
+    assertNull(comment1.getDeletedDttm());
 
-    Comment pageElement2 = comments.getContent().get(1);
-    assertTrue(pageElement2.getId() != null && pageElement2.getId() > 0);
-    assertEquals(gatheringId, pageElement2.getGatheringId());
-    assertEquals(2L, pageElement2.getMember().getId());
-    assertEquals("두 번째 댓글입니다.", pageElement2.getCommentContent());
-    assertNotNull(pageElement2.getCreatedDttm());
-    assertNotNull(pageElement2.getUpdatedDttm());
-    assertNull(pageElement2.getDeletedDttm());
+    Comment comment2 = comments.getContent().get(1);
+    assertEquals(2L, comment2.getId());
+    assertEquals(gatheringId, comment2.getGatheringId());
+    assertEquals(2L, comment2.getMember().getId());
+    assertEquals("comment2", comment2.getCommentContent());
+    assertNotNull(comment2.getCreatedDttm());
+    assertNotNull(comment2.getUpdatedDttm());
+    assertNull(comment2.getDeletedDttm());
   }
 
 }

--- a/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.withus.withmebe.comment.entity.Comment;
-import com.withus.withmebe.member.repository.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -14,12 +13,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@TestPropertySource(locations = "classpath:application-test.yml")
 @Sql(scripts = "classpath:comment/testdata.sql")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 class CommentRepositoryTest {

--- a/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.withus.withmebe.comment.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.withus.withmebe.comment.entity.Comment;
+import com.withus.withmebe.member.entity.Member;
+import com.withus.withmebe.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+@Sql(scripts = "classpath:comment/testdata.sql")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class CommentRepositoryTest {
+
+  @Autowired
+  private CommentRepository commentRepository;
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  private final long gatheringId = 1L;
+
+  @Test
+  void readCommentsByGatheringId() {
+    //given
+
+    Pageable pageable = PageRequest.of(0,10);
+    //when
+    Page<Comment> comments = commentRepository.findCommentsByGatheringId(gatheringId, pageable);
+
+    //then
+
+    assertEquals(2, comments.getTotalElements());
+    assertEquals(1, comments.getTotalPages());
+
+    Comment pageElement1 = comments.getContent().get(0);
+    assertTrue(pageElement1.getId() != null && pageElement1.getId() > 0);
+    assertEquals(gatheringId, pageElement1.getGatheringId());
+    assertEquals(1L, pageElement1.getMember().getId());
+    assertEquals("첫 번째 댓글입니다.", pageElement1.getCommentContent());
+    assertNotNull(pageElement1.getCreatedDttm());
+    assertNotNull(pageElement1.getUpdatedDttm());
+    assertNull(pageElement1.getDeletedDttm());
+
+    Comment pageElement2 = comments.getContent().get(1);
+    assertTrue(pageElement2.getId() != null && pageElement2.getId() > 0);
+    assertEquals(gatheringId, pageElement2.getGatheringId());
+    assertEquals(2L, pageElement2.getMember().getId());
+    assertEquals("두 번째 댓글입니다.", pageElement2.getCommentContent());
+    assertNotNull(pageElement2.getCreatedDttm());
+    assertNotNull(pageElement2.getUpdatedDttm());
+    assertNull(pageElement2.getDeletedDttm());
+  }
+
+}

--- a/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/withus/withmebe/comment/repository/CommentRepositoryTest.java
@@ -43,7 +43,7 @@ class CommentRepositoryTest {
     Comment comment1 = comments.getContent().get(0);
     assertEquals(1L, comment1.getId());
     assertEquals(gatheringId, comment1.getGatheringId());
-    assertEquals(1L, comment1.getMember().getId());
+    assertEquals(1L, comment1.getWriter().getId());
     assertEquals("comment1", comment1.getCommentContent());
     assertNotNull(comment1.getCreatedDttm());
     assertNotNull(comment1.getUpdatedDttm());
@@ -52,7 +52,7 @@ class CommentRepositoryTest {
     Comment comment2 = comments.getContent().get(1);
     assertEquals(2L, comment2.getId());
     assertEquals(gatheringId, comment2.getGatheringId());
-    assertEquals(2L, comment2.getMember().getId());
+    assertEquals(2L, comment2.getWriter().getId());
     assertEquals("comment2", comment2.getCommentContent());
     assertNotNull(comment2.getCreatedDttm());
     assertNotNull(comment2.getUpdatedDttm());

--- a/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
@@ -112,14 +112,14 @@ class CommentServiceTest {
 
     CommentResponse commentResponse1 = commentResponses.getContent().get(0);
     assertEquals(comment1.getId(), commentResponse1.id());
-    assertEquals(comment1.getMember().getNickName(), commentResponse1.nickName());
+    assertEquals(comment1.getWriter().getNickName(), commentResponse1.nickName());
     assertEquals(comment1.getCommentContent(), commentResponse1.commentContent());
     assertEquals(comment1.getCreatedDttm(), commentResponse1.createdDttm());
     assertEquals(comment1.getUpdatedDttm(), commentResponse1.updatedDttm());
 
     CommentResponse commentResponse2 = commentResponses.getContent().get(1);
     assertEquals(comment2.getId(), commentResponse2.id());
-    assertEquals(comment2.getMember().getNickName(), commentResponse2.nickName());
+    assertEquals(comment2.getWriter().getNickName(), commentResponse2.nickName());
     assertEquals(comment2.getCommentContent(), commentResponse2.commentContent());
     assertEquals(comment2.getCreatedDttm(), commentResponse2.createdDttm());
     assertEquals(comment2.getUpdatedDttm(), commentResponse2.updatedDttm());
@@ -244,10 +244,10 @@ class CommentServiceTest {
     return member;
   }
 
-  private Comment getStubbedNewComment(long commentId, long gatheringId, Member member,
+  private Comment getStubbedNewComment(long commentId, long gatheringId, Member requester,
       AddCommentRequest request) {
     Comment comment = Comment.builder()
-        .member(member)
+        .writer(requester)
         .commentContent(request.commentContent())
         .gatheringId(gatheringId)
         .build();
@@ -259,7 +259,7 @@ class CommentServiceTest {
 
   private Comment getStubbedComment(long commentId, long gatheringId, Member member) {
     Comment comment = Comment.builder()
-        .member(member)
+        .writer(member)
         .commentContent("댓글" + commentId)
         .gatheringId(gatheringId)
         .build();

--- a/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
@@ -1,0 +1,107 @@
+package com.withus.withmebe.comment.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.withus.withmebe.comment.dto.request.AddCommentRequest;
+import com.withus.withmebe.comment.dto.response.CommentResponse;
+import com.withus.withmebe.comment.entity.Comment;
+import com.withus.withmebe.comment.repository.CommentRepository;
+import com.withus.withmebe.common.exception.CustomException;
+import com.withus.withmebe.common.exception.ExceptionCode;
+import com.withus.withmebe.member.entity.Member;
+import com.withus.withmebe.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @InjectMocks
+  private CommentService commentService;
+
+  private final long memberId = 1L;
+  private final long gatheringId = 1L;
+
+  private final long commentId = 1L;
+
+  @Test
+  void seccessToCreateComment() {
+    //given
+    AddCommentRequest request = new AddCommentRequest("댓글");
+    Member requester = getStubbedMember(memberId);
+    Comment comment = getStubbedComment(commentId, gatheringId, requester, request);
+
+    given(memberRepository.findById(anyLong()))
+        .willReturn(Optional.of(new Member()));
+    given(commentRepository.save(any()))
+        .willReturn(comment);
+
+    //when
+    CommentResponse commentResponse = commentService.createComment(memberId, gatheringId,
+        request);
+
+    //then
+    assertEquals(commentId, commentResponse.id());
+    assertEquals(requester.getNickName(), commentResponse.nickName());
+    assertEquals(request.commentContent(), commentResponse.commentContent());
+    assertNotNull(commentResponse.createdDttm());
+    assertNotNull(commentResponse.updatedDttm());
+  }
+
+
+  private Member getStubbedMember(long memberId) {
+    Member member = Member.builder()
+        .nickName("홍길동" + memberId)
+        .build();
+    ReflectionTestUtils.setField(member, "id", memberId);
+    return member;
+  }
+
+  private Comment getStubbedComment(long commentId, long gatheringId, Member member,
+      AddCommentRequest request) {
+    Comment comment = Comment.builder()
+        .member(member)
+        .commentContent(request.commentContent())
+        .gatheringId(gatheringId)
+        .build();
+    ReflectionTestUtils.setField(comment, "id", commentId);
+    ReflectionTestUtils.setField(comment, "createdDttm", LocalDateTime.now());
+    ReflectionTestUtils.setField(comment, "updatedDttm", LocalDateTime.now());
+    return comment;
+  }
+
+  private Comment getStubbedComment(long commentId, long gatheringId, Member member) {
+    Comment comment = Comment.builder()
+        .member(member)
+        .commentContent("댓글" + commentId)
+        .gatheringId(gatheringId)
+        .build();
+    ReflectionTestUtils.setField(comment, "id", commentId);
+    ReflectionTestUtils.setField(comment, "createdDttm", LocalDateTime.now());
+    ReflectionTestUtils.setField(comment, "updatedDttm", LocalDateTime.now());
+    return comment;
+  }
+}

--- a/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
@@ -177,6 +177,26 @@ class CommentServiceTest {
     assertEquals(HttpStatus.FORBIDDEN, exception.getHttpStatus());
   }
 
+  @Test
+  void seccessToDeleteComment() {
+    //given
+    Member writer = getStubbedMember(memberId);
+    Comment comment = getStubbedComment(commentId, gatheringId, writer);
+
+    given(commentRepository.findById(anyLong()))
+        .willReturn(Optional.of(comment));
+
+    //when
+    CommentResponse commentResponse = commentService.deleteComment(memberId, commentId);
+
+    //then
+    assertEquals(commentId, commentResponse.id());
+    assertEquals(writer.getNickName(), commentResponse.nickName());
+    assertEquals(comment.getCommentContent(), commentResponse.commentContent());
+    assertNotNull(commentResponse.createdDttm());
+    assertNotNull(commentResponse.updatedDttm());
+  }
+
   private Member getStubbedMember(long memberId) {
     Member member = Member.builder()
         .nickName("홍길동" + memberId)

--- a/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
@@ -85,6 +85,39 @@ class CommentServiceTest {
     assertEquals(HttpStatus.NOT_FOUND, exception.getHttpStatus());
   }
 
+  @Test
+  void successToReadComments() {
+    //given
+    Pageable pageable = PageRequest.of(0, 10);
+    Member writer1 = getStubbedMember(memberId);
+    Member writer2 = getStubbedMember(memberId + 1);
+    Comment comment1 = getStubbedComment(commentId, gatheringId, writer1);
+    Comment comment2 = getStubbedComment(commentId + 1, gatheringId, writer2);
+
+    given(commentRepository.findCommentsByGatheringId(gatheringId, pageable))
+        .willReturn(new PageImpl<Comment>(List.of(comment1, comment2), pageable, 2));
+
+    //when
+    Page<CommentResponse> commentResponses = commentService.readComments(gatheringId, pageable);
+    //then
+    assertEquals(2, commentResponses.getTotalElements());
+    assertEquals(1, commentResponses.getTotalPages());
+    assertEquals(0, commentResponses.getNumber());
+
+    CommentResponse commentResponse1 = commentResponses.getContent().get(0);
+    assertEquals(comment1.getId(), commentResponse1.id());
+    assertEquals(comment1.getMember().getNickName(), commentResponse1.nickName());
+    assertEquals(comment1.getCommentContent(), commentResponse1.commentContent());
+    assertEquals(comment1.getCreatedDttm(), commentResponse1.createdDttm());
+    assertEquals(comment1.getUpdatedDttm(), commentResponse1.updatedDttm());
+
+    CommentResponse commentResponse2 = commentResponses.getContent().get(1);
+    assertEquals(comment2.getId(), commentResponse2.id());
+    assertEquals(comment2.getMember().getNickName(), commentResponse2.nickName());
+    assertEquals(comment2.getCommentContent(), commentResponse2.commentContent());
+    assertEquals(comment2.getCreatedDttm(), commentResponse2.createdDttm());
+    assertEquals(comment2.getUpdatedDttm(), commentResponse2.updatedDttm());
+  }
 
   private Member getStubbedMember(long memberId) {
     Member member = Member.builder()

--- a/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
@@ -14,6 +14,7 @@ import com.withus.withmebe.comment.entity.Comment;
 import com.withus.withmebe.comment.repository.CommentRepository;
 import com.withus.withmebe.common.exception.CustomException;
 import com.withus.withmebe.common.exception.ExceptionCode;
+import com.withus.withmebe.gathering.repository.GatheringRepository;
 import com.withus.withmebe.member.entity.Member;
 import com.withus.withmebe.member.repository.MemberRepository;
 import java.time.LocalDateTime;
@@ -40,6 +41,9 @@ class CommentServiceTest {
   @Mock
   private CommentRepository commentRepository;
 
+  @Mock
+  private GatheringRepository gatheringRepository;
+
   @InjectMocks
   private CommentService commentService;
 
@@ -54,6 +58,8 @@ class CommentServiceTest {
     Member requester = getStubbedMember(memberId);
     Comment comment = getStubbedNewComment(commentId, gatheringId, requester, request);
 
+    given(gatheringRepository.existsById(gatheringId))
+        .willReturn(true);
     given(memberRepository.findById(anyLong()))
         .willReturn(Optional.of(new Member()));
     given(commentRepository.save(any()))

--- a/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 
 import com.withus.withmebe.comment.dto.request.AddCommentRequest;
 import com.withus.withmebe.comment.dto.request.SetCommentRequest;

--- a/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/withus/withmebe/comment/service/CommentServiceTest.java
@@ -71,6 +71,20 @@ class CommentServiceTest {
     assertNotNull(commentResponse.updatedDttm());
   }
 
+  @Test
+  void failToCreateCommentByFailedToReadRequester() {
+    //given
+    given(memberRepository.findById(anyLong()))
+        .willReturn(Optional.empty());
+
+    //when
+    CustomException exception = assertThrows(CustomException.class,
+        () -> commentService.createComment(memberId, gatheringId, new AddCommentRequest("댓글")));
+    //then
+    assertEquals(ExceptionCode.ENTITY_NOT_FOUND.getMessage(), exception.getMessage());
+    assertEquals(HttpStatus.NOT_FOUND, exception.getHttpStatus());
+  }
+
 
   private Member getStubbedMember(long memberId) {
     Member member = Member.builder()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  jwt:
+    secret: ZGF5b25lLXNwcmluZy1ib290LWRpdmlkZW5kLXByb2plY3QtdHV0b3JpYWwtand0LXNlY3JldC1rZXkK
+  jpa:
+    generate-ddl: false
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;MODE=MySQL
+    username: withus
+  h2:
+    console:
+      enabled: true

--- a/src/test/resources/comment/testdata.sql
+++ b/src/test/resources/comment/testdata.sql
@@ -1,0 +1,12 @@
+INSERT INTO Member (member_id, email, password, nickName, birthDate, gender, phoneNumber, profileimg, role, signupPath, signupDttm, membership, createdDttm, updatedDttm, deletedDttm)
+VALUES
+    (1L, 'user1@example.com', 'password1', 'User1', '1990-01-01', 'MALE', '01012345678', 'profile1.jpg', 'ROLE_MEMBER', 'NORMAL', NOW(), 'FREE', NOW(), NOW(), null),
+    (2L, 'user2@example.com', 'password2', 'User2', '1995-05-05', 'FEMALE', '01098765432', 'profile2.jpg', 'ROLE_MEMBER', 'NORMAL', NOW(), 'FREE', NOW(), NOW(), null),
+    (3L, 'user3@example.com', 'password3', 'User3', '1988-12-25', 'OTHER', '01011112222', 'profile3.jpg', 'ROLE_MEMBER', 'NORMAL', NOW(), 'FREE', NOW(), NOW(), NOW());
+
+INSERT INTO Comment (comment_id, gatheringId, member_id, commentContent, createdDttm, updatedDttm, deletedDttm)
+VALUES
+    (1L, 1L, 1L, 'comment1', NOW(), NOW(), null),
+    (2L, 1L, 2L, 'comment2', NOW(), NOW(), null),
+    (3L, 2L, 1L, 'comment3', NOW(), NOW(), null),
+    (4L, 1L, 1L, 'comment4', NOW(), NOW(), NOW());


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 멘토링 피드백 사항 반영
  - deleteComment 불필요한 transactional 어노테이션 제거
  - fromEntity 메서드 제거 및 toResponse 메서드 추가  
  - fetch join을 entitygraph 어노테이션을 이용한 방식으로 변경

-  테스트용 설정 및 디펜던시 추가

- 코드 리팩터링
  - 사용자 id를 컨트롤러에서 Authentication 어노테이션을 이용해 획득하는 방식으로 변경
  - addComment 메서드 gatheringId로 모임 존재 여부 체크 추가
  - requestBody에 검증 추가

### 테스트
- commentRepository
  - readCommentsByGatheringId 테스트 추가
  - 테스트 데이터용 sql문 추가

- commentService
  - createComment 성공 테스트 추가
  - createComment 실패 테스트 추가
  - readComments 성공 테스트 추가
  - updateComment 성공 테스트 추가
  - updateComment 실패 테스트 추가
  - deleteComment 성공 테스트 추가
  - deleteComment 실패 테스트 추가

- commentController
  - addComment 성공 테스트 추가
  - addComment 실패 테스트 추가
  - getComments 성공 테스트 추가
  - getComments 실패 테스트 추가
  - setComment 성공 테스트 추가
  - setComment 실패 테스트 추가
  - deleteComment 성공 테스트 추가
  - deleteComment 실패 테스트 추가