### PR TITLE
🔀 Merge branches: Feature/refactor AuthSmsServiceTest 테스트 오류 고침

### DIFF
--- a/src/test/java/com/withus/withmebe/member/service/AuthSmsServiceTest.java
+++ b/src/test/java/com/withus/withmebe/member/service/AuthSmsServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
 
 import com.withus.withmebe.common.exception.CustomException;
 import com.withus.withmebe.common.service.RedisStringService;
@@ -40,18 +41,14 @@ class AuthSmsServiceTest {
   private RedisStringService redisService;
   @Mock
   private MemberRepository memberRepository;
+  DefaultMessageService messageService = mock(DefaultMessageService.class);
   @InjectMocks
   private AuthSmsService authSmsService;
-  DefaultMessageService messageService = mock(DefaultMessageService.class);
 
 
   @BeforeEach
   void setUp() {
-    initializeMessageService();
     setSenderPhoneNumber();
-    setTextContentTemplate();
-    setExpirationSeconds();
-    setAuthCodeLength();
     setAuthSmsPrefix();
   }
 
@@ -79,6 +76,7 @@ class AuthSmsServiceTest {
   @Test
   @DisplayName("휴대폰 인증번호 확인 후 저장 - 성공")
   void authCodeAndSetPhoneNumber() {
+
     // Given
     String phoneNumber = "010-1234-5678";
     String authenticationText = "ZRC8U2";
@@ -169,31 +167,8 @@ class AuthSmsServiceTest {
     assertEquals(ENTITY_NOT_FOUND.getMessage(), customException.getMessage());
   }
 
-
-
-  private void initializeMessageService() {
-    String apiKey = "NCSXQ8ZDMCPA3OE5";
-    String apiSecretKey = "OHHDZBMNXNBS07WZ70UYNFWYSEGCURMI";
-    String domain = "https://api.coolsms.co.kr";
-    ReflectionTestUtils.setField(authSmsService, "messageService",
-        NurigoApp.INSTANCE.initialize(apiKey, apiSecretKey, domain));
-  }
-
   private void setSenderPhoneNumber() {
-    ReflectionTestUtils.setField(authSmsService, "senderPhoneNumber", "01097799391");
-  }
-
-  private void setTextContentTemplate() {
-    ReflectionTestUtils.setField(authSmsService, "textContentTemplate",
-        "[with me] 인증 문자는 [%s] 입니다.");
-  }
-
-  private void setExpirationSeconds() {
-    ReflectionTestUtils.setField(authSmsService, "expirationSeconds", 60);
-  }
-
-  private void setAuthCodeLength() {
-    ReflectionTestUtils.setField(authSmsService, "authCodeLength", 6);
+    ReflectionTestUtils.setField(authSmsService, "senderPhoneNumber", "010-9999-9999");
   }
 
   private void setAuthSmsPrefix() {

--- a/src/test/java/com/withus/withmebe/member/service/AuthSmsServiceTest.java
+++ b/src/test/java/com/withus/withmebe/member/service/AuthSmsServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.withSettings;
 
 import com.withus.withmebe.common.exception.CustomException;
 import com.withus.withmebe.common.service.RedisStringService;
@@ -20,7 +19,6 @@ import com.withus.withmebe.member.dto.auth.response.SendAuthSmsResponseDto;
 import com.withus.withmebe.member.entity.Member;
 import com.withus.withmebe.member.repository.MemberRepository;
 import java.util.Optional;
-import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.MessageType;
 import net.nurigo.sdk.message.response.SingleMessageSentResponse;
 import net.nurigo.sdk.message.service.DefaultMessageService;

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### 변경사항
**AS-IS**
- AuthSmsServiceTest에서 DefaultMessageService를 mock으로 바꾸는 과정에서 오류가 있었음.
**TO-BE**
- AuthSmsServiceTest 오류 해결
  - 필요한 설정 파일 추가
  - mock을 사용함으로써 안쓰는 메서드 삭제
