### PR TITLE
🔀 Merge: Feature/like 좋아요 상태 변경되면 모임의 좋아요 수 업데이트 하는 기능 추가

### DIFF
--- a/src/main/java/com/withus/withmebe/gathering/entity/GatheringLike.java
+++ b/src/main/java/com/withus/withmebe/gathering/entity/GatheringLike.java
@@ -42,8 +42,4 @@ public class GatheringLike extends BaseEntity {
     this.isLiked = !this.isLiked;
     return this;
   }
-
-  public boolean isMember(long memberId) {
-    return this.memberId == memberId;
-  }
 }

--- a/src/main/java/com/withus/withmebe/gathering/entity/GatheringLike.java
+++ b/src/main/java/com/withus/withmebe/gathering/entity/GatheringLike.java
@@ -3,9 +3,12 @@ package com.withus.withmebe.gathering.entity;
 import com.withus.withmebe.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,8 +23,9 @@ public class GatheringLike extends BaseEntity {
   @Column(name = "like_id")
   private Long id;
 
-  @Column(nullable = false)
-  private Long gatheringId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "gathering_id", nullable = false)
+  private Gathering gathering;
 
   @Column(nullable = false)
   private Long memberId;
@@ -29,8 +33,8 @@ public class GatheringLike extends BaseEntity {
   private Boolean isLiked = true;
 
   @Builder
-  public GatheringLike(long gatheringId, long memberId) {
-    this.gatheringId = gatheringId;
+  public GatheringLike(Gathering gathering, long memberId) {
+    this.gathering = gathering;
     this.memberId = memberId;
   }
 

--- a/src/main/java/com/withus/withmebe/gathering/repository/GatheringLikeRepository.java
+++ b/src/main/java/com/withus/withmebe/gathering/repository/GatheringLikeRepository.java
@@ -1,5 +1,6 @@
 package com.withus.withmebe.gathering.repository;
 
+import com.withus.withmebe.gathering.entity.Gathering;
 import com.withus.withmebe.gathering.entity.GatheringLike;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface GatheringLikeRepository extends JpaRepository<GatheringLike, Long> {
 
-  Optional<GatheringLike> findByMemberIdAndGatheringId(Long memberId, Long gatheringId);
+  Optional<GatheringLike> findByMemberIdAndGathering(Long memberId, Gathering gathering);
 
-  Long countByGatheringIdAndIsLikedIsTrue(Long gatheringId);
+  Long countGatheringLikeByGatheringAndAndIsLikedIsTrue(Gathering gathering);
 }

--- a/src/main/java/com/withus/withmebe/gathering/repository/GatheringLikeRepository.java
+++ b/src/main/java/com/withus/withmebe/gathering/repository/GatheringLikeRepository.java
@@ -1,15 +1,16 @@
 package com.withus.withmebe.gathering.repository;
 
-import com.withus.withmebe.gathering.entity.Gathering;
 import com.withus.withmebe.gathering.entity.GatheringLike;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GatheringLikeRepository extends JpaRepository<GatheringLike, Long> {
 
-  Optional<GatheringLike> findByMemberIdAndGathering(Long memberId, Gathering gathering);
+  @EntityGraph(attributePaths = "gathering")
+  Optional<GatheringLike> findByMemberIdAndGathering_Id(Long memberId, Long gatheringId);
 
-  Long countGatheringLikeByGatheringAndAndIsLikedIsTrue(Gathering gathering);
+  Long countGatheringLikesByGathering_IdAndIsLikedIsTrue(Long gatheringId);
 }

--- a/src/test/java/com/withus/withmebe/gathering/controller/GatheringLikeControllerTest.java
+++ b/src/test/java/com/withus/withmebe/gathering/controller/GatheringLikeControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.withus.withmebe.common.exception.CustomException;
+import com.withus.withmebe.common.exception.ExceptionCode;
 import com.withus.withmebe.gathering.service.GatheringLikeService;
 import com.withus.withmebe.security.jwt.filter.JwtAuthenticationFilter;
 import org.junit.jupiter.api.Test;
@@ -57,5 +59,19 @@ class GatheringLikeControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .with(SecurityMockMvcRequestPostProcessors.csrf()))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockCustomUser
+  void failToUpdateLikeByNotFount() throws Exception {
+    //given
+    given(gatheringLikeService.doLike(anyLong(), anyLong()))
+        .willThrow(new CustomException(ExceptionCode.ENTITY_NOT_FOUND));
+    //when
+    //then
+    mockMvc.perform(put(BASE_URL + "?gatheringid=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(SecurityMockMvcRequestPostProcessors.csrf()))
+        .andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/com/withus/withmebe/gathering/repository/GatheringLikeRepositoryTest.java
+++ b/src/test/java/com/withus/withmebe/gathering/repository/GatheringLikeRepositoryTest.java
@@ -29,14 +29,14 @@ class GatheringLikeRepositoryTest {
     //given
     //when
     Optional<GatheringLike> optionalGatheringLike = gatheringLikeRepository
-        .findByMemberIdAndGatheringId(MEMBER_ID, GATHERING_ID);
+        .findByMemberIdAndGathering_Id(MEMBER_ID, GATHERING_ID);
 
     //then
     GatheringLike gatheringLike = optionalGatheringLike.get();
 
-    assertNotNull(gatheringLike.getGatheringId());
+    assertNotNull(gatheringLike.getGathering());
     assertEquals(MEMBER_ID, gatheringLike.getMemberId());
-    assertEquals(GATHERING_ID, gatheringLike.getGatheringId());
+    assertEquals(GATHERING_ID, gatheringLike.getGathering().getId());
     assertNotNull(gatheringLike.getCreatedDttm());
     assertNotNull(gatheringLike.getUpdatedDttm());
     assertNull(gatheringLike.getDeletedDttm());
@@ -47,6 +47,6 @@ class GatheringLikeRepositoryTest {
     //given
     //when
     //then
-    assertEquals(1L, gatheringLikeRepository.countByGatheringIdAndIsLikedIsTrue(GATHERING_ID));
+    assertEquals(1L, gatheringLikeRepository.countGatheringLikesByGathering_IdAndIsLikedIsTrue(GATHERING_ID));
   }
 }

--- a/src/test/java/util/objectprovider/GatheringLikeProvider.java
+++ b/src/test/java/util/objectprovider/GatheringLikeProvider.java
@@ -8,7 +8,9 @@ public class GatheringLikeProvider {
   private GatheringLikeProvider() {
   }
   public static GatheringLike getStubbedGatheringLike(boolean isLiked) {
-    GatheringLike gatheringLike = new GatheringLike();
+    GatheringLike gatheringLike = GatheringLike.builder()
+        .gathering(GatheringProvider.getStubbedGathering(1L,1L))
+        .build();
     ReflectionTestUtils.setField(gatheringLike, "isLiked", isLiked);
     return gatheringLike;
   }

--- a/src/test/resources/sql/gathering/likedata.sql
+++ b/src/test/resources/sql/gathering/likedata.sql
@@ -1,4 +1,7 @@
+INSERT INTO gathering (gathering_id, member_id, title, content, gathering_type, maximum_participant, day, time, recruitment_start_dt, recruitment_end_dt, category, address, detailed_address, lat, lng, main_img, participants_type, fee, participant_selection_method, status, created_dttm, updated_dttm, deleted_dttm)
+VALUES (1L, 1L, 'Title1', 'Content1', 'MEETING', 30, '2024-05-11', '12:00:00', '2024-05-11', '2024-05-12', 'Category1', 'Address1', 'DetailedAddress1', 37.1234, 127.5678, 'MainImage1', 'ADULT', 0, 'FIRST_COME', 'PROGRESS', NOW(), NOW(), NULL);
+
+
 INSERT INTO gathering_like (gathering_id, member_id, is_liked, created_dttm, updated_dttm, deleted_dttm)
 VALUES (1L, 1L, TRUE, NOW(), NOW(), NULL),
-       (1L, 2L, FALSE, NOW(), NOW(), NULL)
-       ;
+       (1L, 2L, FALSE, NOW(), NOW(), NULL);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
 - GatheringLike - Gatheing 엔티티 매핑 되도록 GathringLike 클래스 수정
 - 좋아요 시 Gathering의 좋아요 수가 업데이트 되도록 기능 추가
 - 변경된 코드에 맞게 테스트 데이터, 테스트 코드 수정
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 