### PR TITLE
🔀 Merge branches: Feature/content-img 멤버-모임 연관관계 설정

### DIFF
--- a/src/main/java/com/withus/withmebe/gathering/controller/GatheringController.java
+++ b/src/main/java/com/withus/withmebe/gathering/controller/GatheringController.java
@@ -9,6 +9,7 @@ import com.withus.withmebe.gathering.dto.response.SetGatheringResponse;
 import com.withus.withmebe.gathering.service.GatheringService;
 import com.withus.withmebe.security.anotation.CurrentMemberId;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +37,7 @@ public class GatheringController {
       @RequestPart(value = "mainImg", required = false) MultipartFile mainImg,
       @RequestPart(value = "subImg1", required = false) MultipartFile subImg1,
       @RequestPart(value = "subImg2", required = false) MultipartFile subImg2,
-      @RequestPart(value = "subImg3", required = false) MultipartFile subImg3) {
+      @RequestPart(value = "subImg3", required = false) MultipartFile subImg3) throws IOException {
     return ResponseEntity.ok(
         gatheringService.createGathering(currentMemberId, addGatheringRequest, mainImg, subImg1,
             subImg2, subImg3));

--- a/src/main/java/com/withus/withmebe/gathering/dto/request/AddGatheringRequest.java
+++ b/src/main/java/com/withus/withmebe/gathering/dto/request/AddGatheringRequest.java
@@ -4,6 +4,7 @@ import com.withus.withmebe.gathering.Type.GatheringType;
 import com.withus.withmebe.gathering.Type.ParticipantSelectionMethod;
 import com.withus.withmebe.gathering.Type.ParticipantsType;
 import com.withus.withmebe.gathering.entity.Gathering;
+import com.withus.withmebe.member.entity.Member;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import javax.validation.constraints.NotBlank;
@@ -12,6 +13,8 @@ import lombok.Getter;
 
 @Getter
 public class AddGatheringRequest {
+  private Member member;
+
   @NotBlank
   private String title;
 
@@ -69,10 +72,10 @@ public class AddGatheringRequest {
 
   private Long likeCount;
 
-  public Gathering toEntity(long memberId, String mainImgUrl, String subImgUrl1,
+  public Gathering toEntity(Member newMember, String mainImgUrl, String subImgUrl1,
       String subImgUrl2, String subImgUrl3) {
     return Gathering.builder()
-        .memberId(memberId)
+        .member(newMember)
         .title(this.title)
         .content(this.content)
         .gatheringType(this.gatheringType)

--- a/src/main/java/com/withus/withmebe/gathering/dto/response/AddGatheringResponse.java
+++ b/src/main/java/com/withus/withmebe/gathering/dto/response/AddGatheringResponse.java
@@ -13,6 +13,12 @@ import lombok.Getter;
 @Getter
 @Builder
 public class AddGatheringResponse {
+    @NotNull
+    private Long memberId;
+
+    @NotNull
+    private Long gatheringId;
+
     @NotBlank
     private String title;
 

--- a/src/main/java/com/withus/withmebe/gathering/dto/response/DeleteGatheringResponse.java
+++ b/src/main/java/com/withus/withmebe/gathering/dto/response/DeleteGatheringResponse.java
@@ -14,6 +14,12 @@ import lombok.Getter;
 @Getter
 @Builder
 public class DeleteGatheringResponse {
+    @NotNull
+    private Long memberId;
+
+    @NotNull
+    private Long gatheringId;
+
     @NotBlank
     private String title;
 

--- a/src/main/java/com/withus/withmebe/gathering/dto/response/SetGatheringResponse.java
+++ b/src/main/java/com/withus/withmebe/gathering/dto/response/SetGatheringResponse.java
@@ -13,6 +13,12 @@ import lombok.Getter;
 @Getter
 @Builder
 public class SetGatheringResponse {
+    @NotNull
+    private Long memberId;
+
+    @NotNull
+    private Long gatheringId;
+
     @NotBlank
     private String title;
 

--- a/src/main/java/com/withus/withmebe/gathering/entity/Gathering.java
+++ b/src/main/java/com/withus/withmebe/gathering/entity/Gathering.java
@@ -15,9 +15,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.Builder;
@@ -34,14 +37,14 @@ import org.hibernate.annotations.Where;
 @Where(clause = "deleted_dttm is null")
 @SQLDelete(sql = "UPDATE gathering SET deleted_dttm = CURRENT_TIMESTAMP WHERE gathering_id = ?")
 public class Gathering extends BaseEntity {
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "gathering_id")
   private Long id;
 
-  @Column(nullable = false)
-  private Long memberId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
 
   @Column(nullable = false)
   private String title;
@@ -108,7 +111,7 @@ public class Gathering extends BaseEntity {
   private Status status = Status.PROGRESS;
 
   @Builder
-  public Gathering(Long memberId, String title, String content, GatheringType gatheringType,
+  public Gathering(Member member,String title, String content, GatheringType gatheringType,
       Long maximumParticipant,
       LocalDate day, LocalTime time,
       LocalDate recruitmentStartDt, LocalDate recruitmentEndDt, String category,
@@ -116,7 +119,7 @@ public class Gathering extends BaseEntity {
       String subImg1, String subImg2, String subImg3,
       ParticipantsType participantsType, Long fee,
       ParticipantSelectionMethod participantSelectionMethod) {
-    this.memberId = memberId;
+    this.member = member;
     this.title = title;
     this.content = content;
     this.gatheringType = gatheringType;
@@ -141,6 +144,8 @@ public class Gathering extends BaseEntity {
 
   public AddGatheringResponse toAddGatheringResponse() {
     return AddGatheringResponse.builder()
+        .memberId(this.member.getId())
+        .gatheringId(this.id)
         .title(this.title)
         .content(this.content)
         .gatheringType(this.gatheringType)
@@ -161,11 +166,14 @@ public class Gathering extends BaseEntity {
         .participantsType(this.participantsType)
         .fee(this.fee)
         .participantSelectionMethod(this.participantSelectionMethod)
+        .likeCount(this.likeCount)
         .build();
   }
 
   public SetGatheringResponse toSetGatheringResponse() {
     return SetGatheringResponse.builder()
+        .memberId(this.member.getId())
+        .gatheringId(this.id)
         .title(this.title)
         .content(this.content)
         .gatheringType(this.gatheringType)
@@ -183,6 +191,7 @@ public class Gathering extends BaseEntity {
         .participantsType(this.participantsType)
         .fee(this.fee)
         .participantSelectionMethod(this.participantSelectionMethod)
+        .likeCount(this.likeCount)
         .build();
   }
 
@@ -214,12 +223,15 @@ public class Gathering extends BaseEntity {
         .participantsType(this.participantsType)
         .fee(this.fee)
         .participantSelectionMethod(this.participantSelectionMethod)
+        .likeCount(this.likeCount)
         .createdDttm(this.getCreatedDttm())
         .build();
   }
 
   public DeleteGatheringResponse toDeleteGatheringResponse() {
     return DeleteGatheringResponse.builder()
+        .memberId(this.member.getId())
+        .gatheringId(this.id)
         .title(this.title)
         .content(this.content)
         .gatheringType(this.gatheringType)
@@ -237,6 +249,7 @@ public class Gathering extends BaseEntity {
         .participantsType(this.participantsType)
         .fee(this.fee)
         .participantSelectionMethod(this.participantSelectionMethod)
+        .likeCount(this.likeCount)
         .build();
   }
 
@@ -247,6 +260,9 @@ public class Gathering extends BaseEntity {
     maximumParticipant = setGatheringRequest.getMaximumParticipant();
     recruitmentStartDt = setGatheringRequest.getRecruitmentStartDt();
     recruitmentEndDt = setGatheringRequest.getRecruitmentEndDt();
+    day = setGatheringRequest.getDay();
+    time = setGatheringRequest.getTime();
+    likeCount = setGatheringRequest.getLikeCount();
     address = setGatheringRequest.getAddress();
     detailedAddress = setGatheringRequest.getDetailedAddress();
     lat = setGatheringRequest.getLat();

--- a/src/main/java/com/withus/withmebe/gathering/repository/GatheringRepository.java
+++ b/src/main/java/com/withus/withmebe/gathering/repository/GatheringRepository.java
@@ -2,13 +2,13 @@ package com.withus.withmebe.gathering.repository;
 
 import com.withus.withmebe.gathering.entity.Gathering;
 import java.util.List;
-import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GatheringRepository extends JpaRepository<Gathering, Long> {
-
+    @EntityGraph(attributePaths = "member", type = EntityGraph.EntityGraphType.FETCH)
     List<Gathering> findAllByOrderByCreatedDttmDesc();
-    List<Gathering> findAllByMemberId(long currentMemberId);
-    Optional<Gathering> findById(Long aLong);
 
+    @EntityGraph(attributePaths = "member", type = EntityGraph.EntityGraphType.FETCH)
+    List<Gathering> findAllByMemberId(long currentMemberId);
 }

--- a/src/main/java/com/withus/withmebe/participation/service/ParticipationService.java
+++ b/src/main/java/com/withus/withmebe/participation/service/ParticipationService.java
@@ -189,7 +189,7 @@ public class ParticipationService {
   }
 
   private boolean isHost(long requesterId, Gathering gathering) {
-    return gathering.getMemberId() == requesterId;
+    return gathering.getMember().getId() == requesterId;
   }
 
   private boolean isProgressingGathering(Gathering gathering) {


### PR DESCRIPTION
### 변경사항

### AS-IS
- 멤버 레퍼지토리 통해 회원객체 로드

### TO-BE
- 멤버-모임 연관관계 설정후 모임 엔티티에서 멤버객체 로드

### 작업 범위
- 멤버-모임 연관관계를 설정한 모임 엔티티에서 멤버 객체를 가져오는 코드를 추가합니다.

### 변경 이유
- 현재는 회원 객체를 멤버 레퍼지토리를 통해 로드하고 있으나, 
  이를 멤버-모임 연관관계를 설정하여 모임 엔티티에서 멤버 객체를 로드하도록 변경하여 더 효율적인 구조로 개선합니다.

### 해당 작업으로 인한 예상 영향
- 모임 엔티티에서 멤버 객체를 직접 로드함으로써 데이터베이스 쿼리 수가 줄어들고, 성능이 향상될 것으로 예상됩니다.