### PR TITLE
♻️ Refactor: 모임 리마인더 리팩터링

### DIFF
--- a/src/main/java/com/withus/withmebe/gathering/Type/GatheringType.java
+++ b/src/main/java/com/withus/withmebe/gathering/Type/GatheringType.java
@@ -1,11 +1,13 @@
 package com.withus.withmebe.gathering.Type;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum GatheringType {
     ALL("all", "전체"),
-    MEETING("meeting","미팅"),
+    MEETING("meeting","모임"),
     EVENT("event","이벤트");
 
     private final String request;

--- a/src/main/java/com/withus/withmebe/participation/entity/Participation.java
+++ b/src/main/java/com/withus/withmebe/participation/entity/Participation.java
@@ -113,4 +113,8 @@ public class Participation extends BaseEntity {
   public boolean statusEquals(Status status) {
     return this.status == status;
   }
+
+  public boolean isValidParticipationStatus() {
+    return !(this.status.equals(Status.CANCELED) || this.status.equals(Status.REJECTED));
+  }
 }

--- a/src/main/java/com/withus/withmebe/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/withus/withmebe/participation/repository/ParticipationRepository.java
@@ -30,7 +30,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
   @EntityGraph(attributePaths = "gathering")
   Page<Participation> findByParticipant_IdAndStatusIsNot(Long requesterId, Status status, Pageable pageable);
-  List<Participation> findAllByGatheringAndStatusEquals(Gathering gathering, Status status);
   List<Participation> findAllByGathering_Id(Long gatheringId);
 
   long countByParticipant_IdAndStatusIsNot(Long requesterId, Status status);


### PR DESCRIPTION
 - 메시지 스트링 포맷으로 생성되게 변경
 - 참가자 리스트 추출하는 부분 상태 무관하게 가져온후 필터링 하도록 변경
 - GatherigType에 Getter 추가
 - GatheringType의 MEETING value 모임으로 변경

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드
- [X] API 테스트 