### PR TITLE
🔀 Merge:Feature/payment 서킷브레이커 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 	testRuntimeOnly 'com.h2database:h2'
 
 	testImplementation "org.mockito:mockito-core:1.+"
+
+	//CircuitBreaker
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/withus/withmebe/payment/circuit/RestTemplateCircuitRecordFailurePredicate.java
+++ b/src/main/java/com/withus/withmebe/payment/circuit/RestTemplateCircuitRecordFailurePredicate.java
@@ -1,0 +1,15 @@
+package com.withus.withmebe.payment.circuit;
+
+import java.util.function.Predicate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Component
+public class RestTemplateCircuitRecordFailurePredicate implements Predicate<Throwable> {
+
+
+  @Override
+  public boolean test(Throwable throwable) {
+    return !(throwable instanceof HttpClientErrorException);
+  }
+}

--- a/src/main/java/com/withus/withmebe/payment/service/PaymentService.java
+++ b/src/main/java/com/withus/withmebe/payment/service/PaymentService.java
@@ -21,6 +21,7 @@ import com.withus.withmebe.payment.repository.PaymentRepository;
 import com.withus.withmebe.payment.type.Currency;
 import com.withus.withmebe.payment.type.PayType;
 import com.withus.withmebe.payment.type.Status;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -72,6 +73,7 @@ public class PaymentService {
   }
 
   @Transactional
+  @CircuitBreaker(name = "approvePayment")
   public PaymentResponse approvePayment(long requesterId, ApprovePaymentRequest request) {
     Payment payment = readPayment(request.getOrdrId());
     validateApprovePaymentRequest(requesterId, request, payment);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,3 +72,21 @@ front:
 festival:
   api:
     url: http://openapi.seoul.go.kr:8088/${FESTIVAL_API_KEY}/json/culturalEventInfo
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        wait-duration-in-open-state: 60s
+        slow-call-rate-threshold: 100
+        slowCallDurationThreshold: 5s
+        automatic-transition-from-open-to-half-open-enabled: true
+    instances:
+      approvePayment:
+        base-config: default
+        recordFailurePredicate: com.withus.withmebe.payment.circuit.RestTemplateCircuitRecordFailurePredicate
+  timelimiter:
+    configs:
+      default:
+        timeout-duration: 6s
+        cancel-running-future: true


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 서킷 브레이커 추가
  - resilience4j 디펜던시 추가
  - resilience4j 설정 추가
    - 열림 상태 유지 : 60초
    - 느린호출 비율한계 : 100% (최근 100회 요청이 전부 느린 호출이면 열림으로 상태 전환)
    - 느린호출 임계값: 5초
    - 열림에서 반열림으로 자동 상태 전환
    - approvePayment 메서드는 recordFailurePredicate로 결과에 따라 자동 실패 처리
  - approvePayment 메서드에 서킷브레이커 적용